### PR TITLE
chore(deps): upgrade macaca-playwright to 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "datahub-nodejs-sdk": "2",
-    "macaca-playwright": "1"
+    "macaca-playwright": "2"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.18.2",


### PR DESCRIPTION
## Summary

  - Upgrade macaca-playwright dependency from 1.x to 2.x

  ## Background

  macaca-playwright 2.0.0 已发布，主要变更是升级 playwright 到 ^1.58.0，以适配 Chromium 下载地址的变化（从 `playwright/builds` 改为 Chrome for Testing 的 `cftUrl`）。

  相关 PR: https://github.com/macacajs/macaca-playwright/pull/55

  ## Changes

  - `package.json`: macaca-playwright "1" → "2"

  ## Compatibility

  - [x] Breaking changes: No
  - [x] Backward compatible: Yes
  - [x] Migration required: No
  ---